### PR TITLE
Migrate build off Java 8 (target Java 17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ First you can clone this repository.
 
 **Pre-requisites**
 * Maven 3.3.9 or above
-* Java 8
+* Java 17
 
 **Building**
 `mvn clean install`

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.alfresco.support</groupId>
 	<artifactId>jmxdump-analyzer-fx</artifactId>
@@ -49,7 +51,7 @@
 				<role>tester</role>
 			</roles>
 		</contributor>
-				<contributor>
+		<contributor>
 			<name>Mark Tunmer</name>
 			<email>mark.tunmer@alfresco.com</email>
 			<organization>Alfresco Support</organization>
@@ -57,7 +59,7 @@
 				<role>tester</role>
 			</roles>
 		</contributor>
-				<contributor>
+		<contributor>
 			<name>Jennie Soria</name>
 			<email>jennie.soria@alfresco.com</email>
 			<organization>Alfresco Expert Support</organization>
@@ -79,7 +81,17 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
+			<version>2.16.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-controls</artifactId>
+			<version>21.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-fxml</artifactId>
+			<version>21.0.2</version>
 		</dependency>
 	</dependencies>
 	<distributionManagement>
@@ -104,8 +116,7 @@
 	</distributionManagement>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.release>17</maven.compiler.release>
 	</properties>
 	<organization>
 		<name>Alfresco Software</name>
@@ -118,20 +129,25 @@
 			<extension>
 				<groupId>org.apache.maven.wagon</groupId>
 				<artifactId>wagon-webdav-jackrabbit</artifactId>
-				<version>2.2</version>
+				<version>3.5.3</version>
 			</extension>
 		</extensions>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.13.0</version>
+			</plugin>
+			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.7.1</version>
 				<configuration>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<archive>
 						<manifest>
-							<mainClass>org.alfresco.support.expert.jmxdumpanalyzerfx.JMXFX</mainClass>
+							<mainClass>org.alfresco.support.expert.jmxdumpanalyzerfx.Launcher</mainClass>
 						</manifest>
 					</archive>
 				</configuration>
@@ -148,7 +164,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.3</version>
+				<version>3.1.1</version>
 				<configuration>
 					<checkModificationExcludes>
 						<checkModificationExclude>release.properties</checkModificationExclude>
@@ -159,12 +175,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
-				<version>3.7.1</version>
+				<version>3.20.0</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.6.2</version>
 			</plugin>
 		</plugins>
 		<resources>
@@ -183,7 +199,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-changes-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.12.1</version>
 				<reportSets>
 					<reportSet>
 						<reports>

--- a/src/main/java/org/alfresco/support/expert/jmxdumpanalyzerfx/Launcher.java
+++ b/src/main/java/org/alfresco/support/expert/jmxdumpanalyzerfx/Launcher.java
@@ -1,0 +1,17 @@
+package org.alfresco.support.expert.jmxdumpanalyzerfx;
+
+/**
+ * Plain entry point for the shaded (jar-with-dependencies) distribution.
+ *
+ * <p>Launching a fat jar via {@code java -jar} whose main class extends
+ * {@link javafx.application.Application} fails on JavaFX 11+ with
+ * "JavaFX runtime components are missing", because the JavaFX modules sit on the
+ * classpath rather than the module path. Delegating through a class that does
+ * not extend {@code Application} sidesteps that launcher check.
+ */
+public class Launcher {
+
+    public static void main(String[] args) {
+        JMXFX.main(args);
+    }
+}


### PR DESCRIPTION
Bump compiler to release 17, pin maven-compiler-plugin, and modernize the long-outdated build tooling (assembly, release, site, project-info, changes, wagon-webdav) and commons-io.

Add a plain Launcher entry point (not extending Application) and point the shaded jar's manifest at it, so `java -jar ...jar-with-dependencies.jar` no longer fails with "JavaFX runtime components are missing" on JavaFX 11+.

Update README prerequisite from Java 8 to Java 17.